### PR TITLE
[Chore] ci/cd 및 docker-compose 세팅

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -83,13 +83,21 @@ jobs:
       - name: Write .env file
         run: |
           cat <<EOF > .env
-          DOCKER_USERNAME=${{secrets.DOCKER_USERNAME }}
+          DOCKER_USERNAME=${{ secrets.DOCKER_USERNAME }}
           DOCKER_REPO=${{ secrets.DOCKER_REPO }}
           DOCKER_IMAGE_VERSION=${{ needs.build.outputs.BUILD_VERSION }}
+
+          POSTGRES_DB=${{ secrets.POSTGRES_DB }}
+          POSTGRES_USER=${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
           EOF
 
-      - name: Stop & Remove Containers
-        run: sudo docker-compose -f docker-compose.dev.yml down
+      - name: Stop app container only
+        run: |
+          if docker ps -a --format '{{.Names}}' | grep -q '^riding-mate-dev$'; then
+            sudo docker stop riding-mate-dev
+            sudo docker rm riding-mate-dev
+          fi
 
       - name: Prune Docker Images
         run: sudo docker image prune -a -f

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,0 +1,98 @@
+name: Deploy dev to AWS EC2
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set Timezone to Asia/Seoul
+        uses: szenius/set-timezone@v2.0
+        with:
+          timezoneLinux: "Asia/Seoul"
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Setup application.yml
+        run: |
+          mkdir -p src/main/resources
+          echo "${{ secrets.APPLICATION_DEV_YML }}" > src/main/resources/application.yml
+
+      - name: Build Spring Project
+        run: ./gradlew clean bootJar
+
+      - name: Get current datetime
+        id: datetime
+        run: echo "datetime=$(date +'%Y%m%d%H%M%S')" >> "$GITHUB_OUTPUT"
+
+      - name: docker login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Docker Build & Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.dev
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:dev-${{ steps.datetime.outputs.datetime }}
+          build-args: JAR_FILE=build/libs/app.jar
+
+      - name: Upload docker-compose.dev.yml
+        uses: actions/upload-artifact@v4
+        with:
+          name: compose-yml
+          path: ./docker-compose.dev.yml
+
+    outputs:
+      BUILD_VERSION: ${{ steps.datetime.outputs.datetime }}
+
+  deploy:
+    runs-on: [self-hosted, app-dev]
+    needs: build
+
+    steps:
+      - name: Download docker-compose.dev.yml
+        uses: actions/download-artifact@v4
+        with:
+          name: compose-yml
+          path: .
+
+      - name: Write .env file
+        run: |
+          cat <<EOF > .env
+          DOCKER_USERNAME=${{secrets.DOCKER_USERNAME }}
+          DOCKER_REPO=${{ secrets.DOCKER_REPO }}
+          DOCKER_IMAGE_VERSION=${{ needs.build.outputs.BUILD_VERSION }}
+          EOF
+
+      - name: Stop & Remove Containers
+        run: sudo docker-compose -f docker-compose.dev.yml down
+
+      - name: Prune Docker Images
+        run: sudo docker image prune -a -f
+
+      - name: Run New Containers
+        run: sudo docker-compose -f docker-compose.dev.yml up -d

--- a/.github/workflows/ci-pr-dev.yml
+++ b/.github/workflows/ci-pr-dev.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+permissions: write-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          echo "${{ secrets.APPLICATION_DEV_YML }}" > ./src/main/resources/application.yml
+
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle Wrapper
+        run: |
+          ./gradlew clean build
+
+      - name: If build fails, notify Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: dev 서버 빌드 실패 알림
+          fields: repo, message, commit, author, action, eventName, ref, workflow, job, took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: failure()

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,6 @@
+FROM openjdk:17-jdk-slim
+
+ARG JAR_FILE=build/libs/ridingMate-0.0.1-SNAPSHOT.jar
+COPY ${JAR_FILE} /app.jar
+
+ENTRYPOINT ["java", "-Xms512m", "-Xmx2g", "-Dspring.profiles.active=prod", "-Duser.timezone=Asia/Seoul", "-jar", "/app.jar"]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,12 +1,44 @@
 version: '3.8'
 
 services:
+  db:
+    image: postgres:15
+    container_name: postgres-dev
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - dev-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
+
   app:
     image: ${DOCKER_USERNAME}/${DOCKER_REPO}:dev-${DOCKER_IMAGE_VERSION}
-    environment:
-      TZ: Asia/Seoul
+    container_name: riding-mate-dev
     ports:
       - "8080:8080"
     env_file:
       - .env
+    environment:
+      TZ: Asia/Seoul
+    networks:
+      - dev-network
+    depends_on:
+      db:
+        condition: service_healthy
     restart: unless-stopped
+
+volumes:
+  postgres-data:
+
+networks:
+  dev-network:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  app:
+    image: ${DOCKER_USERNAME}/${DOCKER_REPO}:dev-${DOCKER_IMAGE_VERSION}
+    environment:
+      TZ: Asia/Seoul
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    restart: unless-stopped


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
1. 스프링 빌드 관리를 docker를 docker-compose로 활용하였습니다.
- dockerfile과 docker-compose 파일을 dev로 분리하여 관리합니다. (이후에 prod 워크플로우와 분리를 위함)
- docker 계정은 inoi.swm 계정을 사용하였으며 해당 정보도 노션에 업데이트 하였습니다. 
+) 추가 docker-compose를 통해 db도 docker container로 실행하도록 하였습니다.

2. ci 워크플로우
- CI는 develop에 pull request시에 실행됩니다.
- gradle 캐싱을 적용하여 gradle 빌드 시 빠르게 빌드가 되도록 하였습니다.
- 빌드에 실패한다면 Slack Webhook을 통해 알림이 오도록 설정하였습니다.
- 현재 테스트 코드는 작성하고있지않아 테스트 관련 설정은 빠졌으나 1차 스프린트 마감 시기 혹은 이후에 테스트 코드 추가 시 관련 설정이 추가될 예정입니다.

## PR 포인트

## 고민과 학습내용
- docker와 ci/cd 워크플로우를 prod 와 dev를 효율적으로 나누고 관리하는 과정에서 고민을 많이 했던 것 같습니다.

## 스크린샷
<img width="674" alt="image" src="https://github.com/user-attachments/assets/f5eb44b7-c42e-4063-aac3-56479fd90382" />
