### PR TITLE
chore: docker 빌드명 오류 수정

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -58,7 +58,7 @@ jobs:
           file: ./Dockerfile.dev
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:dev-${{ steps.datetime.outputs.datetime }}
-          build-args: JAR_FILE=build/libs/app.jar
+          build-args: JAR_FILE=build/libs/ridingMate-0.0.1-SNAPSHOT.jar
 
       - name: Upload docker-compose.dev.yml
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
dockerfile에서와 ci-dev.yml에서 빌드명이 달라 발생하던 오류를 수정하였습니다.

## PR 포인트

## 고민과 학습내용

## 스크린샷
