### PR TITLE
[Feat] 공통 예외 처리 및 API 응답 구조 개선

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
@@ -8,6 +8,7 @@ import com.ridingmate.api_server.domain.route.exception.RouteSuccessCode;
 import com.ridingmate.api_server.domain.route.facade.RouteFacade;
 import com.ridingmate.api_server.global.exception.ApiResponse;
 import com.ridingmate.api_server.global.exception.SuccessCode;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,7 +32,7 @@ public class RouteController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<CreateRouteResponse>> createRoute(@RequestBody CreateRouteRequest request) {
+    public ResponseEntity<ApiResponse<CreateRouteResponse>> createRoute(@Valid @RequestBody CreateRouteRequest request) {
         CreateRouteResponse response = routeFacade.createRoute(request);
         return ResponseEntity.
                 status(RouteSuccessCode.ROUTE_CREATED.getStatus())

--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
@@ -2,8 +2,12 @@ package com.ridingmate.api_server.domain.route.controller;
 
 import com.ridingmate.api_server.domain.route.dto.request.CreateRouteRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteSegmentRequest;
+import com.ridingmate.api_server.domain.route.dto.response.CreateRouteResponse;
 import com.ridingmate.api_server.domain.route.dto.response.RouteSegmentResponse;
+import com.ridingmate.api_server.domain.route.exception.RouteSuccessCode;
 import com.ridingmate.api_server.domain.route.facade.RouteFacade;
+import com.ridingmate.api_server.global.exception.ApiResponse;
+import com.ridingmate.api_server.global.exception.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,14 +23,18 @@ public class RouteController {
     private final RouteFacade routeFacade;
 
     @PostMapping("/segment")
-    public ResponseEntity<RouteSegmentResponse> previewRoute(@RequestBody RouteSegmentRequest request) {
+    public ResponseEntity<ApiResponse<RouteSegmentResponse>>previewRoute(@RequestBody RouteSegmentRequest request) {
         RouteSegmentResponse response = routeFacade.generateSegment(request);
-        return ResponseEntity.ok(response);
+        return ResponseEntity
+                .status(RouteSuccessCode.SEGMENT_CREATED.getStatus())
+                .body(ApiResponse.success(RouteSuccessCode.SEGMENT_CREATED, response));
     }
 
     @PostMapping
-    public ResponseEntity<Void> createRoute(@RequestBody CreateRouteRequest request) {
-        routeFacade.createRoute(request);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<ApiResponse<CreateRouteResponse>> createRoute(@RequestBody CreateRouteRequest request) {
+        CreateRouteResponse response = routeFacade.createRoute(request);
+        return ResponseEntity.
+                status(RouteSuccessCode.ROUTE_CREATED.getStatus())
+                .body(ApiResponse.success(RouteSuccessCode.ROUTE_CREATED, response));
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
@@ -1,0 +1,12 @@
+package com.ridingmate.api_server.domain.route.dto.response;
+
+import java.time.Duration;
+
+public record CreateRouteResponse(
+        Long routeId,
+        String name,
+        long totalDuration,
+        double totalDistance,
+        double averageGradient
+) {
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
@@ -1,12 +1,10 @@
 package com.ridingmate.api_server.domain.route.dto.response;
 
-import java.time.Duration;
-
 public record CreateRouteResponse(
         Long routeId,
         String name,
         long totalDuration,
         double totalDistance,
-        double averageGradient
+        double totalElevationGain
 ) {
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteSegmentResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteSegmentResponse.java
@@ -5,8 +5,8 @@ import java.util.List;
 public record RouteSegmentResponse(
         List<Double> bbox,
         List<List<Double>> geometry,
+        int totalDuration,
         double totalDistance,
-        double totalDuration,
         double averageGradient
 ) {
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteSuccessCode.java
@@ -1,0 +1,16 @@
+package com.ridingmate.api_server.domain.route.exception;
+
+import com.ridingmate.api_server.global.exception.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RouteSuccessCode implements SuccessCode {
+    SEGMENT_CREATED(HttpStatus.CREATED, "경로 세그먼트가 생성되었습니다."),
+    ROUTE_CREATED(HttpStatus.CREATED, "경로가 생성되었습니다.")
+    ;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
@@ -14,6 +14,9 @@ import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.LineString;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
 @Component
 @RequiredArgsConstructor
 public class RouteFacade {
@@ -30,12 +33,17 @@ public class RouteFacade {
         LineString routeLine = GeometryUtil.polylineToLineString(request.polyline());
         //TODO 썸네일 이미지 생성 및 추가 기능 구현 필요
         Route route = routeService.createRoute(request, routeLine);
+
+        double distanceKm = new BigDecimal(route.getTotalDistance())
+                .setScale(2, RoundingMode.DOWN)
+                .doubleValue();
+
         return new CreateRouteResponse(
                 route.getId(),
                 route.getName(),
                 route.getTotalDuration().toMinutes(),
-                route.getTotalDistance(),
-                route.getAverageGradient()
+                distanceKm,
+                route.getTotalElevationGain()
                 );
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
@@ -2,7 +2,9 @@ package com.ridingmate.api_server.domain.route.facade;
 
 import com.ridingmate.api_server.domain.route.dto.request.CreateRouteRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteSegmentRequest;
+import com.ridingmate.api_server.domain.route.dto.response.CreateRouteResponse;
 import com.ridingmate.api_server.domain.route.dto.response.RouteSegmentResponse;
+import com.ridingmate.api_server.domain.route.entity.Route;
 import com.ridingmate.api_server.domain.route.service.RouteService;
 import com.ridingmate.api_server.global.client.OrsClient;
 import com.ridingmate.api_server.global.client.OrsMapper;
@@ -24,9 +26,16 @@ public class RouteFacade {
         return OrsMapper.toRouteSegmentResponse(orsResponse);
     }
 
-    public void createRoute(CreateRouteRequest request) {
+    public CreateRouteResponse createRoute(CreateRouteRequest request) {
         LineString routeLine = GeometryUtil.polylineToLineString(request.polyline());
         //TODO 썸네일 이미지 생성 및 추가 기능 구현 필요
-        routeService.crateRoute(request, routeLine);
+        Route route = routeService.createRoute(request, routeLine);
+        return new CreateRouteResponse(
+                route.getId(),
+                route.getName(),
+                route.getTotalDuration().toMinutes(),
+                route.getTotalDistance(),
+                route.getAverageGradient()
+                );
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
@@ -16,7 +16,7 @@ public class RouteService {
     private final RouteRepository routeRepository;
     private final UserRepository userRepository;
 
-    public void crateRoute(CreateRouteRequest request, LineString routeLine) {
+    public Route createRoute(CreateRouteRequest request, LineString routeLine) {
         double averageGradient = calculateAverageGradient(request.elevationGain(), request.distance());
 
         User mockUser = userRepository.findById(1L)
@@ -32,7 +32,7 @@ public class RouteService {
                 .averageGradient(averageGradient)
                 .build();
 
-       routeRepository.save(route);
+       return routeRepository.save(route);
     }
 
     private double calculateAverageGradient(double totalElevationGain, double totalDistance) {

--- a/src/main/java/com/ridingmate/api_server/global/client/OrsMapper.java
+++ b/src/main/java/com/ridingmate/api_server/global/client/OrsMapper.java
@@ -9,11 +9,13 @@ public class OrsMapper {
         OrsRouteResponse.Properties props = feature.properties();
         OrsRouteResponse.Summary summary = props.summary();
 
+        int durationMinutes = (int) Math.round(summary.duration() / 60.0);
+
         return new RouteSegmentResponse(
                 feature.bbox(),
                 feature.geometry().coordinates(),
+                durationMinutes,
                 summary.distance(),
-                summary.duration(),
                 props.ascent()
         );
     }

--- a/src/main/java/com/ridingmate/api_server/global/exception/ApiResponse.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ApiResponse.java
@@ -1,0 +1,37 @@
+package com.ridingmate.api_server.global.exception;
+
+import lombok.*;
+import org.springframework.validation.BindingResult;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class ApiResponse<T> {
+
+    private int status;
+    private String code;
+    private String message;
+    private T data;
+
+    public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
+        return ApiResponse.<T>builder()
+                .status(successCode.getStatus().value())
+                .code(successCode.getCode())
+                .message(successCode.getMessage())
+                .data(data)
+                .build();
+    }
+    public static <T> ApiResponse<T> success(SuccessCode code) {
+        return success(code, null);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode code, T data) {
+        return ApiResponse.<T>builder()
+                .status(code.getStatus().value())
+                .code(code.getCode())
+                .message(code.getMessage())
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/global/exception/ApiResponse.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ApiResponse.java
@@ -1,7 +1,7 @@
 package com.ridingmate.api_server.global.exception;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
-import org.springframework.validation.BindingResult;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -10,14 +10,17 @@ import org.springframework.validation.BindingResult;
 public class ApiResponse<T> {
 
     private int status;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String code;
+
     private String message;
+
     private T data;
 
     public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
         return ApiResponse.<T>builder()
                 .status(successCode.getStatus().value())
-                .code(successCode.getCode())
                 .message(successCode.getMessage())
                 .data(data)
                 .build();

--- a/src/main/java/com/ridingmate/api_server/global/exception/ApiResponse.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ApiResponse.java
@@ -3,6 +3,8 @@ package com.ridingmate.api_server.global.exception;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.*;
 
+import java.util.List;
+
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -16,7 +18,11 @@ public class ApiResponse<T> {
 
     private String message;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private T data;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private List<ErrorResponse.FieldError> errors;
 
     public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
         return ApiResponse.<T>builder()
@@ -29,12 +35,12 @@ public class ApiResponse<T> {
         return success(code, null);
     }
 
-    public static <T> ApiResponse<T> error(ErrorCode code, T data) {
+    public static <T> ApiResponse<T> error(ErrorCode code, List<ErrorResponse.FieldError> errors) {
         return ApiResponse.<T>builder()
                 .status(code.getStatus().value())
                 .code(code.getCode())
                 .message(code.getMessage())
-                .data(data)
+                .errors(errors)
                 .build();
     }
 }

--- a/src/main/java/com/ridingmate/api_server/global/exception/BaseCode.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/BaseCode.java
@@ -2,6 +2,8 @@ package com.ridingmate.api_server.global.exception;
 
 import org.springframework.http.HttpStatus;
 
-public interface ErrorCode extends BaseCode {
-    String getCode();
+public interface BaseCode {
+    HttpStatus getStatus();
+
+    String getMessage();
 }

--- a/src/main/java/com/ridingmate/api_server/global/exception/BusinessException.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/BusinessException.java
@@ -1,0 +1,19 @@
+package com.ridingmate.api_server.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(final ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/global/exception/ErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ErrorCode.java
@@ -1,0 +1,11 @@
+package com.ridingmate.api_server.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+
+    String getCode();
+
+    String getMessage();
+}

--- a/src/main/java/com/ridingmate/api_server/global/exception/ErrorResponse.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ErrorResponse.java
@@ -1,0 +1,77 @@
+package com.ridingmate.api_server.global.exception;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+
+    private int status;
+    private String code;
+    private String message;
+    private List<FieldError> errors;
+
+    private ErrorResponse(ErrorCode code) {
+        this.status = code.getStatus().value();
+        this.code = code.getCode();
+        this.message = code.getMessage();
+        this.errors = new ArrayList<>();
+    }
+
+    private ErrorResponse(final ErrorCode code,  final String message) {
+        this.status = code.getStatus().value();
+        this.code = code.getCode();
+        this.message = message;
+    }
+
+    private ErrorResponse(ErrorCode code, List<FieldError> errors) {
+        this.status = code.getStatus().value();
+        this.code = code.getCode();
+        this.message = code.getMessage();
+        this.errors = errors;
+    }
+
+    public static ErrorResponse of(final ErrorCode code) {
+        return new ErrorResponse(code);
+    }
+
+    public static ErrorResponse of(final ErrorCode code,  final String message){
+        return new ErrorResponse(code, message);
+    }
+
+
+    public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+        return new ErrorResponse(code, FieldError.of(bindingResult));
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class FieldError {
+        private String field;
+        private String value;
+        private String reason;
+
+        public static List<FieldError> of(final BindingResult bindingResult) {
+            List<org.springframework.validation.FieldError> fieldErrors =  bindingResult.getFieldErrors();
+            return fieldErrors.stream()
+                    .map(error -> new FieldError(
+                            error.getField(),
+                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+                            error.getDefaultMessage()))
+                    .collect(Collectors.toList());
+        }
+
+        FieldError(String field, String value, String reason) {
+            this.field = field;
+            this.value = value;
+            this.reason = reason;
+        }
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/GlobalErrorCode.java
@@ -1,0 +1,22 @@
+package com.ridingmate.api_server.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "GLOBAL_001", "잘못된 요청입니다."),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "GLOBAL_002", "요청 데이터가 유효하지 않습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "GLOBAL_003", "허용되지 않은 HTTP 메서드입니다."),
+
+    FORBIDDEN(HttpStatus.FORBIDDEN, "GLOBAL_011", "권한이 없습니다."),
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "GLOBAL_100", "서버 내부 오류가 발생했습니다."),
+    ;
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,114 @@
+package com.ridingmate.api_server.global.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.nio.file.AccessDeniedException;
+
+/**
+ * 전역 예외 처리 핸들러
+ * 모든 Controller 단에서 발생할 수 있는 예외를 통합 처리하여
+ * 일관된 응답 포맷(ApiResponse<ErrorResponse>)으로 반환한다.
+ */
+@ControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+    /**
+     * @RequestBody 유효성 검사 실패 (javax.validation.Valid 등) 시 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("MethodArgumentNotValidException", e);
+        ErrorResponse error = ErrorResponse.of(GlobalErrorCode.VALIDATION_ERROR, e.getBindingResult());
+        return ResponseEntity
+                .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
+                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, error));
+    }
+
+    /**
+     * @ModelAttribute 등에서 유효성 검사 실패 시 발생
+     */
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleBindException(BindException e) {
+        log.error("BindException", e);
+        ErrorResponse error = ErrorResponse.of(GlobalErrorCode.VALIDATION_ERROR, e.getBindingResult());
+        return ResponseEntity
+                .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
+                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, error));
+    }
+
+    /**
+     * @RequestParam 등에서 enum 타입과 매칭 실패 시 발생
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        log.error("MethodArgumentTypeMismatchException", e);
+        return ResponseEntity
+                .status(GlobalErrorCode.BAD_REQUEST.getStatus())
+                .body(ApiResponse.error(GlobalErrorCode.BAD_REQUEST, null));
+    }
+
+    /**
+     * 지원하지 않는 HTTP 메서드 호출 시 발생 (ex. GET → POST만 지원)
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+        log.error("HttpRequestMethodNotSupportedException", e);
+        return ResponseEntity
+                .status(GlobalErrorCode.METHOD_NOT_ALLOWED.getStatus())
+                .body(ApiResponse.error(GlobalErrorCode.METHOD_NOT_ALLOWED, null));
+    }
+
+    /**
+     * 인증은 되었으나 권한이 없는 경우 발생 (403 Forbidden)
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleAccessDenied(AccessDeniedException e) {
+        log.error("AccessDeniedException", e);
+        return ResponseEntity
+                .status(GlobalErrorCode.FORBIDDEN.getStatus())
+                .body(ApiResponse.error(GlobalErrorCode.FORBIDDEN, null));
+    }
+
+    /**
+     * 비즈니스 로직에서 명시적으로 발생시킨 커스텀 예외 처리
+     */
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleBusiness(BusinessException e) {
+        log.error("BusinessException", e);
+        ErrorCode code = e.getErrorCode();
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ApiResponse.error(code, null));
+    }
+
+    /**
+     * @Validated @RequestParam, @PathVariable 등에 유효성 검사 실패 시 발생
+     */
+    @ExceptionHandler(ConstraintViolationException.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleConstraintViolation(ConstraintViolationException e) {
+        log.error("ConstraintViolationException", e);
+        return ResponseEntity
+                .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
+                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, null));
+    }
+
+    /**
+     * 위에서 처리되지 않은 나머지 모든 예외에 대한 최종 예외 처리
+     */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ApiResponse<ErrorResponse>> handleGeneric(Exception e) {
+        log.error("Unhandled Exception", e);
+        return ResponseEntity
+                .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+                .body(ApiResponse.error(GlobalErrorCode.INTERNAL_SERVER_ERROR, null));
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/GlobalExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.nio.file.AccessDeniedException;
+import java.util.List;
 
 /**
  * 전역 예외 처리 핸들러
@@ -27,10 +28,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException", e);
-        ErrorResponse error = ErrorResponse.of(GlobalErrorCode.VALIDATION_ERROR, e.getBindingResult());
+        List<ErrorResponse.FieldError> fieldErrors = ErrorResponse.FieldError.of(e.getBindingResult());
         return ResponseEntity
                 .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
-                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, error));
+                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, fieldErrors));
     }
 
     /**
@@ -39,10 +40,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BindException.class)
     protected ResponseEntity<ApiResponse<ErrorResponse>> handleBindException(BindException e) {
         log.error("BindException", e);
-        ErrorResponse error = ErrorResponse.of(GlobalErrorCode.VALIDATION_ERROR, e.getBindingResult());
+        List<ErrorResponse.FieldError> fieldErrors = ErrorResponse.FieldError.of(e.getBindingResult());
         return ResponseEntity
                 .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
-                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, error));
+                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, fieldErrors));
     }
 
     /**

--- a/src/main/java/com/ridingmate/api_server/global/exception/SuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/SuccessCode.java
@@ -1,20 +1,4 @@
 package com.ridingmate.api_server.global.exception;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-
-@Getter
-@RequiredArgsConstructor
-public enum SuccessCode {
-    SELECT_SUCCESS(HttpStatus.OK, "200", "조회 요청이 성공했습니다."),
-    DELETE_SUCCESS(HttpStatus.OK, "200", "삭제 요청이 성공했습니다."),
-    INSERT_SUCCESS(HttpStatus.CREATED, "201", "삽입 요청이 성공했습니다."),
-    UPDATE_SUCCESS(HttpStatus.NO_CONTENT, "204", "업데이트 요청이 성공했습니다.")
-    ;
-
-    private final HttpStatus status;
-    private final String code;
-    private final String message;
+public interface SuccessCode extends BaseCode{
 }
-

--- a/src/main/java/com/ridingmate/api_server/global/exception/SuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/SuccessCode.java
@@ -1,0 +1,20 @@
+package com.ridingmate.api_server.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessCode {
+    SELECT_SUCCESS(HttpStatus.OK, "200", "조회 요청이 성공했습니다."),
+    DELETE_SUCCESS(HttpStatus.OK, "200", "삭제 요청이 성공했습니다."),
+    INSERT_SUCCESS(HttpStatus.CREATED, "201", "삽입 요청이 성공했습니다."),
+    UPDATE_SUCCESS(HttpStatus.NO_CONTENT, "204", "업데이트 요청이 성공했습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}
+


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
서버에 요청이 들어왔을 때 반환하는 응답과 오류 구조를 통일시키기 위해 커스텀 응답 객체를 생성하였습니다.

1. 응답 구조
- BaseCode를 기반으로 ErrorCode, Success Code를 상황에 맞게 반환합니다.
- ErrorCode는 status와 message를 담고있습니다. ErrorCode는 추가적으로 고유 code를 반환합니다.
- 커스텀 응답 객체인 ApiResponse를 한번 더 ResponseEntity를 감싼 형태로 반환하여 실제 응답 status와 일치하도록 하였습니다.
2. 전역 예외 처리
- @ControllerAdvice 기반으로 애플리케이션 전역의 공통 예외 처리 적용
- 스프링 기본 예외:
- MethodArgumentNotValidException (Validation 실패), BindException 등
- BusinessException (커스텀 비즈니스 예외)
- 미처리 예외 fallback → Exception
- 모든 예외는 ApiResponse 구조로 일관되게 반환되도록 처리
![image](https://github.com/user-attachments/assets/01de1b22-4cfd-4aea-8794-780b692d2fa1)
- 위의 사진처럼 도메인별로 공통 예외를 상속한 도메인별 커스텀 예외를 생성하여 처리
3. 경로 생성 api에 해당 내용을 적용하였습니다. 아래는 공통 응답 구조가 적용된 경로 생성 응답 예시입니다.
@begong313 @Ag-crane API 요청 시 아래의 응답 형식 참고해주시면 감사하겠습니다.
```
{
    "status": 201,
    "message": "경로가 생성되었습니다.",
    "data": {
        "routeId": 12,
        "name": "도심 단거리 라이딩",
        "totalDuration": 30,
        "totalDistance": 5.21,
        "totalElevationGain": 35.0
    }
}
```

만약 오류가 발생하게 되면 아래와 같은 형태로 응답을 주게 됩니다. (api 요청 시 HTTP 메서드를 잘못 선택했을 때의 예시)
```
{
    "status": 405,
    "code": "GLOBAL_003",
    "message": "허용되지 않은 HTTP 메서드입니다."
}
```
Validation 오류의 경우 errors라는 FieldError의 내용이 함께 반환됩니다.
```
{
    "status": 400,
    "code": "GLOBAL_002",
    "message": "요청 데이터가 유효하지 않습니다.",
    "errors": [
        {
            "field": "name",
            "value": "",
            "reason": "공백일 수 없습니다"
        }
    ]
}
```

## PR 포인트

## 고민과 학습내용

## 스크린샷

