### PR TITLE
[Feat] 경로 생성시 썸네일 생성 구현

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -61,4 +61,8 @@ public class Route extends BaseTimeEntity {
         this.totalElevationGain = totalElevationGain;
         this.averageGradient = averageGradient;
     }
+
+    public void updateThumbnailImagePath(String thumbnailImagePath) {
+        this.thumbnailImagePath = thumbnailImagePath;
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
@@ -10,6 +10,7 @@ import org.locationtech.jts.geom.LineString;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -34,11 +35,20 @@ public class RouteService {
                 .averageGradient(averageGradient)
                 .build();
 
-       return routeRepository.save(route);
+        routeRepository.save(route);
+
+        route.updateThumbnailImagePath(createThumbnailImagePath(route.getId()));
+
+       return route;
     }
 
     private double calculateAverageGradient(double totalElevationGain, double totalDistance) {
         if (totalDistance == 0) return 0.0;
         return (totalElevationGain / totalDistance) * 100;
+    }
+
+    private String createThumbnailImagePath(Long routeId) {
+        String uuid = UUID.randomUUID().toString();
+        return String.format("ridingmate/route-thumbnails/%d/%s.png", routeId, uuid);
     }
 }

--- a/src/main/java/com/ridingmate/api_server/global/util/GeometryUtil.java
+++ b/src/main/java/com/ridingmate/api_server/global/util/GeometryUtil.java
@@ -1,19 +1,81 @@
 package com.ridingmate.api_server.global.util;
 
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.LineString;
-import org.locationtech.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.*;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class GeometryUtil {
 
     private static final GeometryFactory factory = new GeometryFactory(new PrecisionModel(), 4326);
 
+    /**
+     * Encoded polyline을 LineString으로 변환 예시: LINESTRING (126.9706 37.5547, 127.0276 37.4979, ...)
+     */
     public static LineString polylineToLineString(String polyline) {
         List<Coordinate> coordinates = PolylineDecoder.decode(polyline);
         return factory.createLineString(coordinates.toArray(new Coordinate[0]));
     }
 
+    /**
+     * LineString의 BBOX(Envelope) 반환
+     */
+    public static Envelope getBoundingBox(LineString line) {
+        return line.getEnvelopeInternal();
+    }
+
+    /**
+     * BBOX를 기반으로 중심 좌표 계산
+     */
+    public static Coordinate getCenterCoordinate(Envelope bbox) {
+        double centerLon = (bbox.getMinX() + bbox.getMaxX()) / 2.0; // 경도
+        double centerLat = (bbox.getMinY() + bbox.getMaxY()) / 2.0; // 위도
+        return new Coordinate(centerLon, centerLat);
+    }
+
+    /**
+     * 한 번에: Polyline으로부터 중심 좌표 반환
+     */
+    public static Coordinate getCenterFromPolyline(String polyline) {
+        LineString line = polylineToLineString(polyline);
+        Envelope bbox = getBoundingBox(line);
+        return getCenterCoordinate(bbox);
+    }
+
+    /**
+     * BBOX로부터 줌레벨 추정
+     */
+    public static int getZoomLevel(Envelope bbox) {
+        double lonDiff = bbox.getMaxX() - bbox.getMinX();
+        double latDiff = bbox.getMaxY() - bbox.getMinY();
+        double maxDiff = Math.max(lonDiff, latDiff);
+
+        double safetyFactor = 0.8;
+
+        double adjustedDiff = maxDiff / safetyFactor;
+
+        // 경도 차이를 기준으로 줌레벨 추정
+        double zoom = Math.log(360 / adjustedDiff) / Math.log(2);
+
+        // 최소,최대 줌레벨 제한
+        int zoomLevel = Math.max(2, Math.min(20, (int) Math.floor(zoom)));
+
+        return zoomLevel;
+    }
+
+    public static int getZoomLevelFromPolyline(String polyline) {
+        LineString line = polylineToLineString(polyline);
+        Envelope bbox = getBoundingBox(line);
+        return getZoomLevel(bbox);
+    }
+
+    /**
+     * Coordinates 리스트를 Geoapify geometry 파라미터용 polyline 문자열로 변환
+     * 예: polyline:127.0535,37.53560,127.05349,37.53559 ...
+     */
+    public static String toGeoapifyPolyline(List<Coordinate> coordinates) {
+        return coordinates.stream()
+                .map(coord -> String.format("%.7f,%.7f", coord.x, coord.y)) // 소수점 7자리로 lon, lat
+                .collect(Collectors.joining(","));
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/infra/aws/s3/S3Manager.java
+++ b/src/main/java/com/ridingmate/api_server/infra/aws/s3/S3Manager.java
@@ -46,6 +46,17 @@ public class S3Manager {
         }
     }
 
+    public void uploadByteFiles(String key, byte[] data) {
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(awsProperty.s3().bucket())
+                .key(key)
+                .contentType("image/png")
+                .build();
+
+        s3Client.putObject(request, RequestBody.fromBytes(data));
+        log.info("S3 업로드 완료: {}", key);
+    }
+
     public String getPresignedUrl(String key) {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                 .bucket(awsProperty.s3().bucket())

--- a/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyClient.java
+++ b/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyClient.java
@@ -1,0 +1,47 @@
+package com.ridingmate.api_server.infra.geoapify;
+
+import com.ridingmate.api_server.global.util.GeometryUtil;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.LineString;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class GeoapifyClient {
+
+    private final GeoapifyProperty geoapifyProperty;
+
+    @Qualifier("geoapifyWebClient")
+    private final WebClient geoapifyWebClient;
+
+    public byte[] getStaticMap(LineString lineString) {
+        Envelope bbox = GeometryUtil.getBoundingBox(lineString);
+        Coordinate center = GeometryUtil.getCenterCoordinate(bbox);
+        String centerParam = String.format("lonlat:%.6f,%.6f", center.x, center.y);
+        int zoom = GeometryUtil.getZoomLevel(bbox);
+
+        List<Coordinate> coordinates = List.of(lineString.getCoordinates());
+        String polyline = GeometryUtil.toGeoapifyPolyline(coordinates);
+        String geometryParam = "polyline:" + polyline +";linecolor:%23ff0000;linewidth:3";
+
+        return geoapifyWebClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("style", "klokantech-basic")
+                        .queryParam("width", 600)
+                        .queryParam("height", 450)
+                        .queryParam("geometry", geometryParam)
+                        .queryParam("center", centerParam)
+                        .queryParam("zoom", zoom)
+                        .queryParam("apiKey", geoapifyProperty.apikey())
+                        .build())
+                .retrieve()
+                .bodyToMono(byte[].class)
+                .block();  // 동기 호출 (필요시 비동기로)
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyConfig.java
+++ b/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyConfig.java
@@ -1,0 +1,32 @@
+package com.ridingmate.api_server.infra.geoapify;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+
+@Configuration
+@EnableConfigurationProperties(GeoapifyProperty.class)
+@RequiredArgsConstructor
+public class GeoapifyConfig {
+
+    private final GeoapifyProperty geoapifyProperty;
+
+    @Bean
+    public WebClient geoapifyWebClient() {
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory();
+        factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
+
+        return WebClient.builder()
+                .baseUrl(geoapifyProperty.baseUrl())
+                .uriBuilderFactory(factory)
+                .build();
+    }
+
+    @Bean
+    public GeoapifyClient geoapifyClient(WebClient geoapifyWebClient) {
+        return new GeoapifyClient(geoapifyProperty, geoapifyWebClient);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyConfig.java
+++ b/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyConfig.java
@@ -16,11 +16,10 @@ public class GeoapifyConfig {
 
     @Bean
     public WebClient geoapifyWebClient() {
-        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory();
+        DefaultUriBuilderFactory factory = new DefaultUriBuilderFactory(geoapifyProperty.baseUrl());
         factory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.NONE);
 
         return WebClient.builder()
-                .baseUrl(geoapifyProperty.baseUrl())
                 .uriBuilderFactory(factory)
                 .build();
     }

--- a/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyProperty.java
+++ b/src/main/java/com/ridingmate/api_server/infra/geoapify/GeoapifyProperty.java
@@ -1,0 +1,13 @@
+package com.ridingmate.api_server.infra.geoapify;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "geoapify")
+public record GeoapifyProperty(
+        @NotBlank
+        String apikey,
+        @NotBlank
+        String baseUrl
+) {
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
경로 생성 요청시 경로 썸네일을 같이 생성합니다. Geoapify의 static map api를 활용하였습니다.
해당 이미지는 S3에 저장됩니다.

@Ag-crane 
현재는 600x450(4:3 비율)로 생성합니다. 프론트에서 작업 이후 적절한 비율 및 적절한 해상도 말씀해주시면 수정하여 반영하도록 하겠습니다.
아래 스크린샷은 제가 임의로 생성한 좌표를 기준으로 폴리라인을 생성하여 테스트한 이미지입니다.
실제 값으로 테스트를 진행해봐야할 것 같습니다.

## PR 포인트

## 고민과 학습내용

## 스크린샷
![image](https://github.com/user-attachments/assets/3bad6746-96e9-4968-a5fd-b53b0187208c)
