### PR TITLE
[Feat] 경로 공유 링크 구현 및 경로 저장 오류 수정

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteApi.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteApi.java
@@ -4,30 +4,52 @@ import com.ridingmate.api_server.domain.route.dto.request.CreateRouteRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteSegmentRequest;
 import com.ridingmate.api_server.domain.route.dto.response.CreateRouteResponse;
 import com.ridingmate.api_server.domain.route.dto.response.RouteSegmentResponse;
-import com.ridingmate.api_server.global.exception.ApiResponse;
+import com.ridingmate.api_server.domain.route.dto.response.ShareRouteResponse;
+import com.ridingmate.api_server.global.exception.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Route API", description = "경로 기능 API")
 public interface RouteApi {
 
     @Operation(summary = "경로 생성을 위한 핀 단위 경로 생성", description = "시작점과 도착점을 통해 자전거 경로를 생성합니다.")
-    public ResponseEntity<ApiResponse<RouteSegmentResponse>>previewRoute(@RequestBody RouteSegmentRequest request);
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "성공: 세그먼트 생성 완료"),
+    })
+    ResponseEntity<CommonResponse<RouteSegmentResponse>> previewRoute(@RequestBody RouteSegmentRequest request);
 
     @Operation(
             summary = "경로 생성 및 저장",
             description = """
-        Polyline 정보를 기반으로 새로운 경로를 생성하고 저장합니다.
-        
-        - name: 경로 이름
-        - polyline: Google Polyline 인코딩 형식
-        - distance: 총 거리 (단위: 미터)
-        - duration: 예상 소요 시간 (단위: 분)
-        - elevationGain: 총 상승 고도 (단위: 미터)
-        """
+            Polyline 정보를 기반으로 새로운 경로를 생성하고 저장합니다.
+            
+            - name: 경로 이름
+            - polyline: Google Polyline 인코딩 형식
+            - distance: 총 거리 (단위: 미터)
+            - duration: 예상 소요 시간 (단위: 분)
+            - elevationGain: 총 상승 고도 (단위: 미터)
+            """
     )
-    public ResponseEntity<ApiResponse<CreateRouteResponse>> createRoute(@Valid @RequestBody CreateRouteRequest request);
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "성공: 경로 생성 완료"),
+    })
+    ResponseEntity<CommonResponse<CreateRouteResponse>> createRoute(@Valid @RequestBody CreateRouteRequest request);
+
+    @Operation(
+            summary = "경로 공유 링크 조회",
+            description = """
+            특정 경로(Route)에 대해 미리 생성된 공유 ID를 기반으로
+            딥링크 형식의 공유 URL을 반환합니다.
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공: 공유 링크 조회 완료"),
+    })
+    ResponseEntity<CommonResponse<ShareRouteResponse>> shareRoute(@PathVariable Long routeId);
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/controller/RouteController.java
@@ -4,18 +4,14 @@ import com.ridingmate.api_server.domain.route.dto.request.CreateRouteRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteSegmentRequest;
 import com.ridingmate.api_server.domain.route.dto.response.CreateRouteResponse;
 import com.ridingmate.api_server.domain.route.dto.response.RouteSegmentResponse;
+import com.ridingmate.api_server.domain.route.dto.response.ShareRouteResponse;
 import com.ridingmate.api_server.domain.route.exception.RouteSuccessCode;
 import com.ridingmate.api_server.domain.route.facade.RouteFacade;
-import com.ridingmate.api_server.global.exception.ApiResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
+import com.ridingmate.api_server.global.exception.CommonResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/routes")
@@ -26,19 +22,28 @@ public class RouteController implements RouteApi{
 
     @Override
     @PostMapping("/segment")
-    public ResponseEntity<ApiResponse<RouteSegmentResponse>>previewRoute(@RequestBody RouteSegmentRequest request) {
+    public ResponseEntity<CommonResponse<RouteSegmentResponse>>previewRoute(@RequestBody RouteSegmentRequest request) {
         RouteSegmentResponse response = routeFacade.generateSegment(request);
         return ResponseEntity
                 .status(RouteSuccessCode.SEGMENT_CREATED.getStatus())
-                .body(ApiResponse.success(RouteSuccessCode.SEGMENT_CREATED, response));
+                .body(CommonResponse.success(RouteSuccessCode.SEGMENT_CREATED, response));
     }
 
     @Override
     @PostMapping
-    public ResponseEntity<ApiResponse<CreateRouteResponse>> createRoute(@Valid @RequestBody CreateRouteRequest request) {
+    public ResponseEntity<CommonResponse<CreateRouteResponse>> createRoute(@Valid @RequestBody CreateRouteRequest request) {
         CreateRouteResponse response = routeFacade.createRoute(request);
         return ResponseEntity.
                 status(RouteSuccessCode.ROUTE_CREATED.getStatus())
-                .body(ApiResponse.success(RouteSuccessCode.ROUTE_CREATED, response));
+                .body(CommonResponse.success(RouteSuccessCode.ROUTE_CREATED, response));
+    }
+
+    @Override
+    @GetMapping("/{routeId}/share")
+    public ResponseEntity<CommonResponse<ShareRouteResponse>> shareRoute(@PathVariable Long routeId) {
+        ShareRouteResponse  response = routeFacade.shareRoute(routeId);
+        return ResponseEntity
+                .status(RouteSuccessCode.SHARE_LINK_FETCHED.getStatus())
+                .body(CommonResponse.success(RouteSuccessCode.SHARE_LINK_FETCHED, response));
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
@@ -2,7 +2,7 @@ package com.ridingmate.api_server.domain.route.dto.response;
 
 public record CreateRouteResponse(
         Long routeId,
-        String name,
+        String title,
         long totalDuration,
         double totalDistance,
         double totalElevationGain

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/ShareRouteResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/ShareRouteResponse.java
@@ -1,0 +1,6 @@
+package com.ridingmate.api_server.domain.route.dto.response;
+
+public record ShareRouteResponse(
+        String shareUrl
+) {
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -28,6 +28,9 @@ public class Route extends BaseTimeEntity {
     @Column(name = "title", nullable = false)
     private String title;
 
+    @Column(name = "share_id", nullable = false)
+    private String shareId;
+
     @Column(name = "route_line", columnDefinition = "geometry(LineString, 4326)", nullable = false)
     private LineString routeLine;
 
@@ -62,12 +65,13 @@ public class Route extends BaseTimeEntity {
     private String gpxFilePath;
 
     @Builder
-    private Route(User user, String title, LineString routeLine, Double totalDistance,
-                  Duration totalDuration, Double totalElevationGain, Double averageGradient,
+    private Route(User user, String title, LineString routeLine, String shareId,
+                  Double totalDistance, Duration totalDuration, Double totalElevationGain, Double averageGradient,
                   Double minLon, Double minLat, Double maxLon, Double maxLat,
                   String thumbnailImagePath, String gpxFilePath) {
         this.user = user;
         this.title = title;
+        this.shareId = shareId;
         this.routeLine = routeLine;
         this.totalDistance = totalDistance;
         this.totalDuration = totalDuration;

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteErrorCode.java
@@ -1,0 +1,18 @@
+package com.ridingmate.api_server.domain.route.exception;
+
+import com.ridingmate.api_server.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RouteErrorCode implements ErrorCode {
+    ROUTE_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUTE_NOT_FOUND", "경로를 찾을 수 없습니다."),
+    SHARE_ID_NOT_FOUND(HttpStatus.NOT_FOUND, "SHARE_ID_NOT_FOUND", "경로의 공유 식별자를 찾을 수 없습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteException.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteException.java
@@ -1,0 +1,10 @@
+package com.ridingmate.api_server.domain.route.exception;
+
+import com.ridingmate.api_server.global.exception.BusinessException;
+
+public class RouteException extends BusinessException {
+
+    public RouteException(RouteErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteSuccessCode.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/exception/RouteSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum RouteSuccessCode implements SuccessCode {
     SEGMENT_CREATED(HttpStatus.CREATED, "경로 세그먼트가 생성되었습니다."),
-    ROUTE_CREATED(HttpStatus.CREATED, "경로가 생성되었습니다.")
+    ROUTE_CREATED(HttpStatus.CREATED, "경로가 생성되었습니다."),
+    SHARE_LINK_FETCHED(HttpStatus.OK, "경로 공유 링크가 조회되었습니다."),
     ;
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
@@ -4,6 +4,7 @@ import com.ridingmate.api_server.domain.route.dto.request.CreateRouteRequest;
 import com.ridingmate.api_server.domain.route.dto.request.RouteSegmentRequest;
 import com.ridingmate.api_server.domain.route.dto.response.CreateRouteResponse;
 import com.ridingmate.api_server.domain.route.dto.response.RouteSegmentResponse;
+import com.ridingmate.api_server.domain.route.dto.response.ShareRouteResponse;
 import com.ridingmate.api_server.domain.route.entity.Route;
 import com.ridingmate.api_server.domain.route.service.RouteService;
 import com.ridingmate.api_server.infra.aws.s3.S3Manager;
@@ -51,5 +52,10 @@ public class RouteFacade {
                 distanceKm,
                 route.getTotalElevationGain()
                 );
+    }
+
+    public ShareRouteResponse shareRoute(Long routeId) {
+        String shareLink = routeService.createShareLink(routeId);
+        return new ShareRouteResponse(shareLink);
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
@@ -39,6 +39,10 @@ public class RouteService {
                 .totalDuration(Duration.ofMinutes(request.duration()))
                 .totalElevationGain(request.elevationGain())
                 .averageGradient(averageGradient)
+                .minLon(request.bbox().get(0))
+                .minLat(request.bbox().get(1))
+                .maxLon(request.bbox().get(2))
+                .maxLat(request.bbox().get(3))
                 .build();
 
         routeRepository.save(route);

--- a/src/main/java/com/ridingmate/api_server/global/config/AppConfigProperties.java
+++ b/src/main/java/com/ridingmate/api_server/global/config/AppConfigProperties.java
@@ -1,0 +1,11 @@
+package com.ridingmate.api_server.global.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("app")
+public record AppConfigProperties(
+        @NotBlank
+        String scheme
+) {
+}

--- a/src/main/java/com/ridingmate/api_server/global/exception/ApiResponse.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ApiResponse.java
@@ -11,8 +11,6 @@ import java.util.List;
 @Builder
 public class ApiResponse<T> {
 
-    private int status;
-
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String code;
 
@@ -26,7 +24,6 @@ public class ApiResponse<T> {
 
     public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
         return ApiResponse.<T>builder()
-                .status(successCode.getStatus().value())
                 .message(successCode.getMessage())
                 .data(data)
                 .build();
@@ -37,7 +34,6 @@ public class ApiResponse<T> {
 
     public static <T> ApiResponse<T> error(ErrorCode code, List<ErrorResponse.FieldError> errors) {
         return ApiResponse.<T>builder()
-                .status(code.getStatus().value())
                 .code(code.getCode())
                 .message(code.getMessage())
                 .errors(errors)

--- a/src/main/java/com/ridingmate/api_server/global/exception/CommonResponse.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/CommonResponse.java
@@ -9,7 +9,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
-public class ApiResponse<T> {
+public class CommonResponse<T> {
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String code;
@@ -22,18 +22,18 @@ public class ApiResponse<T> {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<ErrorResponse.FieldError> errors;
 
-    public static <T> ApiResponse<T> success(SuccessCode successCode, T data) {
-        return ApiResponse.<T>builder()
+    public static <T> CommonResponse<T> success(SuccessCode successCode, T data) {
+        return CommonResponse.<T>builder()
                 .message(successCode.getMessage())
                 .data(data)
                 .build();
     }
-    public static <T> ApiResponse<T> success(SuccessCode code) {
+    public static <T> CommonResponse<T> success(SuccessCode code) {
         return success(code, null);
     }
 
-    public static <T> ApiResponse<T> error(ErrorCode code, List<ErrorResponse.FieldError> errors) {
-        return ApiResponse.<T>builder()
+    public static <T> CommonResponse<T> error(ErrorCode code, List<ErrorResponse.FieldError> errors) {
+        return CommonResponse.<T>builder()
                 .code(code.getCode())
                 .message(code.getMessage())
                 .errors(errors)

--- a/src/main/java/com/ridingmate/api_server/global/exception/ErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ErrorCode.java
@@ -1,7 +1,5 @@
 package com.ridingmate.api_server.global.exception;
 
-import org.springframework.http.HttpStatus;
-
 public interface ErrorCode extends BaseCode {
     String getCode();
 }

--- a/src/main/java/com/ridingmate/api_server/global/exception/ErrorResponse.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/ErrorResponse.java
@@ -13,26 +13,22 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
 
-    private int status;
     private String code;
     private String message;
     private List<FieldError> errors;
 
     private ErrorResponse(ErrorCode code) {
-        this.status = code.getStatus().value();
         this.code = code.getCode();
         this.message = code.getMessage();
         this.errors = new ArrayList<>();
     }
 
     private ErrorResponse(final ErrorCode code,  final String message) {
-        this.status = code.getStatus().value();
         this.code = code.getCode();
         this.message = message;
     }
 
     private ErrorResponse(ErrorCode code, List<FieldError> errors) {
-        this.status = code.getStatus().value();
         this.code = code.getCode();
         this.message = code.getMessage();
         this.errors = errors;

--- a/src/main/java/com/ridingmate/api_server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ridingmate/api_server/global/exception/GlobalExceptionHandler.java
@@ -26,90 +26,90 @@ public class GlobalExceptionHandler {
      * @RequestBody 유효성 검사 실패 (javax.validation.Valid 등) 시 발생
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    protected ResponseEntity<CommonResponse<ErrorResponse>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         log.error("MethodArgumentNotValidException", e);
         List<ErrorResponse.FieldError> fieldErrors = ErrorResponse.FieldError.of(e.getBindingResult());
         return ResponseEntity
                 .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
-                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, fieldErrors));
+                .body(CommonResponse.error(GlobalErrorCode.VALIDATION_ERROR, fieldErrors));
     }
 
     /**
      * @ModelAttribute 등에서 유효성 검사 실패 시 발생
      */
     @ExceptionHandler(BindException.class)
-    protected ResponseEntity<ApiResponse<ErrorResponse>> handleBindException(BindException e) {
+    protected ResponseEntity<CommonResponse<ErrorResponse>> handleBindException(BindException e) {
         log.error("BindException", e);
         List<ErrorResponse.FieldError> fieldErrors = ErrorResponse.FieldError.of(e.getBindingResult());
         return ResponseEntity
                 .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
-                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, fieldErrors));
+                .body(CommonResponse.error(GlobalErrorCode.VALIDATION_ERROR, fieldErrors));
     }
 
     /**
      * @RequestParam 등에서 enum 타입과 매칭 실패 시 발생
      */
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    protected ResponseEntity<ApiResponse<ErrorResponse>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+    protected ResponseEntity<CommonResponse<ErrorResponse>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
         log.error("MethodArgumentTypeMismatchException", e);
         return ResponseEntity
                 .status(GlobalErrorCode.BAD_REQUEST.getStatus())
-                .body(ApiResponse.error(GlobalErrorCode.BAD_REQUEST, null));
+                .body(CommonResponse.error(GlobalErrorCode.BAD_REQUEST, null));
     }
 
     /**
      * 지원하지 않는 HTTP 메서드 호출 시 발생 (ex. GET → POST만 지원)
      */
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    protected ResponseEntity<ApiResponse<ErrorResponse>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
+    protected ResponseEntity<CommonResponse<ErrorResponse>> handleMethodNotSupported(HttpRequestMethodNotSupportedException e) {
         log.error("HttpRequestMethodNotSupportedException", e);
         return ResponseEntity
                 .status(GlobalErrorCode.METHOD_NOT_ALLOWED.getStatus())
-                .body(ApiResponse.error(GlobalErrorCode.METHOD_NOT_ALLOWED, null));
+                .body(CommonResponse.error(GlobalErrorCode.METHOD_NOT_ALLOWED, null));
     }
 
     /**
      * 인증은 되었으나 권한이 없는 경우 발생 (403 Forbidden)
      */
     @ExceptionHandler(AccessDeniedException.class)
-    protected ResponseEntity<ApiResponse<ErrorResponse>> handleAccessDenied(AccessDeniedException e) {
+    protected ResponseEntity<CommonResponse<ErrorResponse>> handleAccessDenied(AccessDeniedException e) {
         log.error("AccessDeniedException", e);
         return ResponseEntity
                 .status(GlobalErrorCode.FORBIDDEN.getStatus())
-                .body(ApiResponse.error(GlobalErrorCode.FORBIDDEN, null));
+                .body(CommonResponse.error(GlobalErrorCode.FORBIDDEN, null));
     }
 
     /**
      * 비즈니스 로직에서 명시적으로 발생시킨 커스텀 예외 처리
      */
     @ExceptionHandler(BusinessException.class)
-    protected ResponseEntity<ApiResponse<ErrorResponse>> handleBusiness(BusinessException e) {
+    protected ResponseEntity<CommonResponse<ErrorResponse>> handleBusiness(BusinessException e) {
         log.error("BusinessException", e);
         ErrorCode code = e.getErrorCode();
         return ResponseEntity
                 .status(code.getStatus())
-                .body(ApiResponse.error(code, null));
+                .body(CommonResponse.error(code, null));
     }
 
     /**
      * @Validated @RequestParam, @PathVariable 등에 유효성 검사 실패 시 발생
      */
     @ExceptionHandler(ConstraintViolationException.class)
-    protected ResponseEntity<ApiResponse<ErrorResponse>> handleConstraintViolation(ConstraintViolationException e) {
+    protected ResponseEntity<CommonResponse<ErrorResponse>> handleConstraintViolation(ConstraintViolationException e) {
         log.error("ConstraintViolationException", e);
         return ResponseEntity
                 .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
-                .body(ApiResponse.error(GlobalErrorCode.VALIDATION_ERROR, null));
+                .body(CommonResponse.error(GlobalErrorCode.VALIDATION_ERROR, null));
     }
 
     /**
      * 위에서 처리되지 않은 나머지 모든 예외에 대한 최종 예외 처리
      */
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ApiResponse<ErrorResponse>> handleGeneric(Exception e) {
+    protected ResponseEntity<CommonResponse<ErrorResponse>> handleGeneric(Exception e) {
         log.error("Unhandled Exception", e);
         return ResponseEntity
                 .status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getStatus())
-                .body(ApiResponse.error(GlobalErrorCode.INTERNAL_SERVER_ERROR, null));
+                .body(CommonResponse.error(GlobalErrorCode.INTERNAL_SERVER_ERROR, null));
     }
 }

--- a/src/main/java/com/ridingmate/api_server/infra/ors/OrsClient.java
+++ b/src/main/java/com/ridingmate/api_server/infra/ors/OrsClient.java
@@ -23,6 +23,9 @@ public class OrsClient {
                 .bodyValue(request)
                 .retrieve()
                 .bodyToMono(OrsRouteResponse.class)
+                .onErrorMap(
+                        throwable -> new OrsException(OrsErrorCode.ORS_SERVER_CALL_FAILED)
+                )
                 .block();
     }
 }

--- a/src/main/java/com/ridingmate/api_server/infra/ors/OrsErrorCode.java
+++ b/src/main/java/com/ridingmate/api_server/infra/ors/OrsErrorCode.java
@@ -1,0 +1,18 @@
+package com.ridingmate.api_server.infra.ors;
+
+import com.ridingmate.api_server.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrsErrorCode implements ErrorCode {
+    ORS_SERVER_CALL_FAILED(HttpStatus.BAD_GATEWAY, "ORS_502", "외부 ORS 서버와의 통신에 실패했습니다."),
+    ORS_MAPPING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ORS_002", "ORS 응답 매핑에 실패했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/ridingmate/api_server/infra/ors/OrsException.java
+++ b/src/main/java/com/ridingmate/api_server/infra/ors/OrsException.java
@@ -1,0 +1,10 @@
+package com.ridingmate.api_server.infra.ors;
+
+import com.ridingmate.api_server.global.exception.BusinessException;
+
+public class OrsException extends BusinessException {
+
+    public OrsException(OrsErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/ridingmate/api_server/infra/ors/OrsMapper.java
+++ b/src/main/java/com/ridingmate/api_server/infra/ors/OrsMapper.java
@@ -5,6 +5,9 @@ import com.ridingmate.api_server.infra.ors.dto.response.OrsRouteResponse;
 
 public class OrsMapper {
     public static RouteSegmentResponse toRouteSegmentResponse(OrsRouteResponse response) {
+        if (response.features() == null || response.features().isEmpty()) {
+            throw new OrsException(OrsErrorCode.ORS_MAPPING_FAILED);
+        }
         OrsRouteResponse.Feature feature = response.features().get(0);
         OrsRouteResponse.Properties props = feature.properties();
         OrsRouteResponse.Summary summary = props.summary();


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
- 경로 공유 링크 조회 기능
- 응답 구조 개선
- 경로 생성시 생기던 오류 수정
- Ors 관련 예외처리

## PR 포인트
1. 경로 공유에 필요한 share_id (UUID 기반 랜덤값)을 추가하여 링크를 통해 해당 경로에 접근 가능하도록 합니다.
```
{
    "message": "경로 공유 링크가 조회되었습니다.",
    "data": {
        "shareUrl": "ridingmate-app/399eb421-46a8-4716-bacb-332a81ebf266"
    }
}
```
- 해당 API를 조회하게 되면 위와 같이 반환되며 UUID 값 앞의 scheme부분은 임시로 작성해둔 값입니다. 추후에 프론트에서 scheme값 알려주시면 반영하도록 하겠습니다.

2. 응답 구조 개선
멘토링때 받은 피드백을 기반으로 status를 응답 body에서 삭제하였습니다.  code부분은 "ROUTE_NOT_FOUND"와 같은 내용으로 수정하여 이후에 추가할 예정입니다. 
```
{
    "code": "GLOBAL_002",
    "message": "요청 데이터가 유효하지 않습니다.",
    "errors": [
        {
            "field": "title",
            "value": "",
            "reason": "공백일 수 없습니다"
        }
    ]
}
```

3. 경로 저장시 발생하던 오류를 수정하였습니다. 추가로 현재 MockUser 데이터를 더미로 사용중인데 개발서버 테이블을 초기화하여 비어있는 상태입니다. 해당 변경사항 성공적으로 반영된 이후 더미데이터 추가하도록 하겠습니다.

## 고민과 학습내용

## 스크린샷
