### PR TITLE
[Feat] 추가 기획에 따른 ERD 구조 개선 및 주행 기록 추가

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/Activity.java
@@ -1,0 +1,53 @@
+package com.ridingmate.api_server.domain.activity.entity;
+
+import com.ridingmate.api_server.domain.user.entity.User;
+import com.ridingmate.api_server.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "activities")
+public class Activity extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "started_at", nullable = false)
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at", nullable = false)
+    private LocalDateTime endedAt;
+
+    /**
+     * 경로 총 거리 (단위: 미터)
+     */
+    @Column(name = "distance", nullable = false)
+    private Double distance;
+
+    /**
+     * 총 소요 시간 (단위: 초)
+     */
+    @Column(name = "duration", nullable = false)
+    private Duration duration;
+
+    /**
+     * 총 상승 고도 (단위: 미터)
+     */
+    @Column(name = "elevation_gain", nullable = false)
+    private Double elevationGain;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityGpsLog.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityGpsLog.java
@@ -1,0 +1,48 @@
+package com.ridingmate.api_server.domain.activity.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "activity_gps_logs")
+public class ActivityGpsLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+
+    @Column(name = "log_time", nullable = false)
+    private LocalDateTime logTime;
+
+    @Column(name = "latitude", nullable = false)
+    private Double latitude;
+
+    @Column(name = "longitude", nullable = false)
+    private Double longitude;
+
+    @Column(name = "elevation")
+    private Double elevation;
+
+    @Column(name = "speed")
+    private Double speed;
+
+    @Column(name = "distance")
+    private Duration distance;
+
+    @Column(name = "heart_rate")
+    private Double heartRate;
+
+    @Column(name = "cadence")
+    private Double cadence;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityImage.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityImage.java
@@ -23,7 +23,7 @@ public class ActivityImage extends BaseTimeEntity {
     @Column(name = "image_path", nullable = false)
     private String image_path;
 
-    @Column(name = "order", nullable = false)
-    private String order;
+    @Column(name = "display_order", nullable = false)
+    private String displayOrder;
 
 }

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityImage.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityImage.java
@@ -1,0 +1,29 @@
+package com.ridingmate.api_server.domain.activity.entity;
+
+import com.ridingmate.api_server.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "activityImages")
+public class ActivityImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "activity_id", nullable = false)
+    private Activity activity;
+
+    @Column(name = "image_path", nullable = false)
+    private String image_path;
+
+    @Column(name = "order", nullable = false)
+    private String order;
+
+}

--- a/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityPerformance.java
+++ b/src/main/java/com/ridingmate/api_server/domain/activity/entity/ActivityPerformance.java
@@ -1,0 +1,50 @@
+package com.ridingmate.api_server.domain.activity.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.Duration;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "activity_performances")
+public class ActivityPerformance {
+
+    @Id
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "activity_id")
+    private Activity activity;
+
+    @Column(name = "average_speed")
+    private Double averageSpeed;
+
+    @Column(name = "max_speed")
+    private Double maxSpeed;
+
+    @Column(name = "moving_time")
+    private Duration movingTime;
+
+    @Column(name = "elevation_loss")
+    private Double elevationLoss;
+
+    @Column(name = "average_cadence")
+    private Double averageCadence;
+
+    @Column(name = "max_cadence")
+    private Double maxCadence;
+
+    @Column(name = "average_heart_rate")
+    private Double averageHeartRate;
+
+    @Column(name = "average_power")
+    private Double averagePower;
+
+    @Column(name = "max_power")
+    private Double maxPower;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/request/CreateRouteRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/request/CreateRouteRequest.java
@@ -6,17 +6,19 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.locationtech.jts.geom.Coordinate;
 
 import java.util.List;
 
 public record CreateRouteRequest(
 
-        @Schema(description = "경로 이름", example = "한강 라이딩 경로")
+        @Schema(description = "경로 제목", example = "한강 라이딩 경로")
         @NotBlank
         String title,
 
-        @Schema(description = "Polyline 경로", example = "o{~vFf`miWvCkGbAaJjGgQxBwF")
+        @Schema(description = "경로 상세 설명", example = "아름다운 한강을 따라 달리는 초심자용 코스입니다.")
+        String description,
+
+        @Schema(description = "경로 Polyline", example = "o{~vFf`miWvCkGbAaJjGgQxBwF")
         @NotEmpty
         String polyline,
 
@@ -24,13 +26,17 @@ public record CreateRouteRequest(
         @NotNull
         Double distance,
 
-        @Schema(description = "총 소요 시간 (초)", example = "3600")
+        @Schema(description = "예상 소요 시간 (초)", example = "3600")
         @NotNull
         Long duration,
 
         @Schema(description = "총 상승 고도 (미터)", example = "120.4")
         @NotNull
         Double elevationGain,
+
+        @Schema(description = "평균 경사도", example = "2.5")
+        @NotNull
+        Double averageGradient,
 
         @Schema(description = "고도 정보 목록", example = "[20.5, 25.0, 30.2]")
         List<Double> elevations,
@@ -39,6 +45,12 @@ public record CreateRouteRequest(
                 description = "경로 Bounding Box 좌표 [minLon, minLat, maxLon, maxLat]",
                 example = "[127.01, 37.50, 127.05, 37.55]"
         )
-        List<Double> bbox
+        List<Double> bbox,
+
+        @Schema(description = "지역 코드", example = "SEOUL_EAST")
+        String region,
+
+        @Schema(description = "난이도", example = "EASY")
+        String difficulty
 
 ) {}

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/request/CreateRouteRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/request/CreateRouteRequest.java
@@ -45,12 +45,5 @@ public record CreateRouteRequest(
                 description = "경로 Bounding Box 좌표 [minLon, minLat, maxLon, maxLat]",
                 example = "[127.01, 37.50, 127.05, 37.55]"
         )
-        List<Double> bbox,
-
-        @Schema(description = "지역 코드", example = "SEOUL_EAST")
-        String region,
-
-        @Schema(description = "난이도", example = "EASY")
-        String difficulty
-
+        List<Double> bbox
 ) {}

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/request/RouteListRequest.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/request/RouteListRequest.java
@@ -3,39 +3,72 @@ package com.ridingmate.api_server.domain.route.dto.request;
 import com.ridingmate.api_server.domain.route.enums.RouteRelationType;
 import com.ridingmate.api_server.domain.route.enums.RouteSortType;
 import io.swagger.v3.oas.annotations.Parameter;
-import lombok.Getter;
-import lombok.Setter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springdoc.core.annotations.ParameterObject;
 
 import java.util.List;
 
-@Getter
-@Setter
-public class RouteListRequest {
-    
-    @Parameter(description = "페이지 번호 (0부터 시작)", example = "0")
-    private int page = 0;
-    
-    @Parameter(description = "페이지 크기", example = "3")
-    private int size = 3;
-    
-    @Parameter(description = "정렬 타입", example = "CREATED_AT_DESC")
-    private RouteSortType sortType = RouteSortType.CREATED_AT_DESC;
-    
-    @Parameter(description = "관계 타입 필터 (여러 값 지정 가능)", example = "OWNER,SHARED")
-    private List<RouteRelationType> relationTypes;
-    
-    @Parameter(description = "최소 거리 (km)", example = "10.0")
-    private Double minDistanceKm;
-    
-    @Parameter(description = "최대 거리 (km)", example = "50.0")
-    private Double maxDistanceKm;
-    
-    @Parameter(description = "최소 고도 상승 (미터)", example = "100.0")
-    private Double minElevationGain;
-    
-    @Parameter(description = "최대 고도 상승 (미터)", example = "500.0")
-    private Double maxElevationGain;
-    
+@ParameterObject
+public record RouteListRequest(
+        @Parameter(
+                description = "페이지 번호 (0부터 시작)",
+                example = "0",
+                schema = @Schema(defaultValue = "0"),
+                required = true
+        )
+        int page,
+
+        @Parameter(
+                description = "페이지 크기",
+                example = "3",
+                schema = @Schema(defaultValue = "3"),
+                required = true
+        )
+        int size,
+
+        @Parameter(
+                description = "정렬 타입",
+                example = "CREATED_AT_DESC",
+                schema = @Schema(defaultValue = "CREATED_AT_DESC"),
+                required = true
+        )
+        RouteSortType sortType,
+
+        @Parameter(
+                description = "관계 타입 필터 (여러 값 지정 가능, 미지정시 전체 선택)",
+                example = "OWNER,SHARED"
+        )
+        List<RouteRelationType> relationTypes,
+
+        @Parameter(
+                description = "최소 거리 (km)",
+                example = "10.0",
+                required = true
+        )
+        Double minDistanceKm,
+
+        @Parameter(
+                description = "최대 거리 (km)",
+                example = "50.0",
+                required = true
+        )
+        Double maxDistanceKm,
+
+        @Parameter(
+                description = "최소 고도 상승 (미터)",
+                example = "100.0",
+                required = true
+        )
+        Double minElevationGain,
+
+        @Parameter(
+                description = "최대 고도 상승 (미터)",
+                example = "500.0",
+                required = true
+        )
+        Double maxElevationGain
+) {
+
     /**
      * 최소 거리를 미터 단위로 변환하여 반환
      * @return 최소 거리 (미터)
@@ -43,7 +76,7 @@ public class RouteListRequest {
     public Double getMinDistanceInMeter() {
         return minDistanceKm != null ? minDistanceKm * 1000 : null;
     }
-    
+
     /**
      * 최대 거리를 미터 단위로 변환하여 반환
      * @return 최대 거리 (미터)

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/CreateRouteResponse.java
@@ -1,10 +1,32 @@
 package com.ridingmate.api_server.domain.route.dto.response;
 
+import com.ridingmate.api_server.domain.route.entity.Route;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record CreateRouteResponse(
+        @Schema(description = "생성된 경로의 ID", example = "1")
         Long routeId,
+
+        @Schema(description = "경로 제목", example = "한강 라이딩")
         String title,
+
+        @Schema(description = "예상 소요 시간 (분)", example = "60")
         long totalDuration,
+
+        @Schema(description = "총 거리 (km)", example = "13.2")
         double totalDistance,
+
+        @Schema(description = "총 상승 고도 (m)", example = "120.4")
         double totalElevationGain
 ) {
+
+    public static CreateRouteResponse from(Route route) {
+        return new CreateRouteResponse(
+                route.getId(),
+                route.getTitle(),
+                route.getDuration().toMinutes(),
+                route.getDistanceInKm(),
+                route.getElevationGain()
+        );
+    }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteListItemResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteListItemResponse.java
@@ -24,23 +24,36 @@ public record RouteListItemResponse(
         Double distance,
 
         @Schema(description = "총 상승 고도 (m)", example = "120.4")
-        Double elevationGain
+        Double elevationGain,
+
+        @Schema(description = "사용자 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "사용자 닉네임", example = "라이더123")
+        String nickname,
+
+        @Schema(description = "프로필 이미지 URL", example = "https://s3.amazonaws.com/bucket/profile-1.jpg")
+        String profileImageUrl
 ) {
 
     /**
-     * Route 엔티티와 썸네일 URL로부터 RouteListItemResponse 생성
+     * Route 엔티티와 썸네일 URL, 프로필 이미지 URL로부터 RouteListItemResponse 생성
      * @param route Route 엔티티
      * @param thumbnailUrl 썸네일 이미지 URL
+     * @param profileImageUrl 프로필 이미지 URL
      * @return RouteListItemResponse DTO
      */
-    public static RouteListItemResponse from(Route route, String thumbnailUrl) {
+    public static RouteListItemResponse from(Route route, String thumbnailUrl, String profileImageUrl) {
         return new RouteListItemResponse(
                 route.getId(),
                 route.getTitle(),
                 thumbnailUrl,
                 route.getCreatedAt(),
                 route.getDistanceInKm(),
-                route.getElevationGain()
+                route.getElevationGain(),
+                route.getUser().getId(),
+                route.getUser().getNickname(),
+                profileImageUrl
         );
     }
 } 

--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteListItemResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteListItemResponse.java
@@ -40,7 +40,7 @@ public record RouteListItemResponse(
                 thumbnailUrl,
                 route.getCreatedAt(),
                 route.getDistanceInKm(),
-                route.getTotalElevationGain()
+                route.getElevationGain()
         );
     }
 } 

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Recommendation.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Recommendation.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "recommendation")
+@Table(name = "recommendations")
 public class Recommendation {
 
     @Id

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Recommendation.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Recommendation.java
@@ -1,0 +1,35 @@
+package com.ridingmate.api_server.domain.route.entity;
+
+import com.ridingmate.api_server.domain.route.enums.RecommendationType;
+import com.ridingmate.api_server.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "recommendation")
+public class Recommendation {
+
+    @Id
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "route_id")
+    private Route route;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "recommendation_type")
+    private RecommendationType recommendationType;
+
+
+    @Builder
+    public Recommendation(Route route, RecommendationType recommendationType) {
+        this.route = route;
+        this.recommendationType = recommendationType;
+    }
+} 

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -28,83 +28,58 @@ public class Route extends BaseTimeEntity {
     @Column(name = "title", nullable = false)
     private String title;
 
-    @Column(name = "share_id", nullable = false)
-    private String shareId;
-
-    @Column(name = "route_line", columnDefinition = "geometry(LineString, 4326)", nullable = false)
-    private LineString routeLine;
+    @Column(name = "description")
+    private String description;
 
     /**
      * 경로 총 거리 (단위: 미터)
      */
-    @Column(name = "total_distance", nullable = false)
-    private Double totalDistance;
+    @Column(name = "distance", nullable = false)
+    private Double distance;
 
     /**
      * 총 소요 시간 (단위: 초)
      */
-    @Column(name = "total_duration", nullable = false)
-    private Duration totalDuration;
+    @Column(name = "duration", nullable = false)
+    private Duration duration;
 
     /**
      * 총 상승 고도 (단위: 미터)
      */
-    @Column(name = "total_elevation_gain", nullable = false)
-    private Double totalElevationGain;
+    @Column(name = "elevation_gain", nullable = false)
+    private Double elevationGain;
 
-    /**
-     * 평균 경사도 (단위: 퍼센트)
-     */
-    @Column(name = "average_gradient", nullable = false)
-    private Double averageGradient;
+    @Column(name = "share_id", nullable = false)
+    private String shareId;
+
+    @Column(name = "region")
+    private String region;
+
+    @Column(name = "difficulty")
+    private String difficulty;
 
     @Column(name = "thumbnail_image_path")
     private String thumbnailImagePath;
 
-    /**
-     * 경로 영역 최소 위도
-     */
-    @Column(name = "minLat", nullable = false)
-    private Double minLat;
+    @OneToOne(mappedBy = "route", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private RouteGeometry routeGeometry;
 
-    /**
-     * 경로 영역 최소 경도
-     */
-    @Column(name = "minLon", nullable = false)
-    private Double minLon;
+    @OneToOne(mappedBy = "route", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private Recommendation recommendation;
 
-    /**
-     * 경로 영역 최대 위도
-     */
-    @Column(name = "maxLat", nullable = false)
-    private Double maxLat;
-
-    /**
-     * 경로 영역 최대 경도
-     */
-    @Column(name = "maxLon", nullable = false)
-    private Double maxLon;
-
-    @Column(name = "gpx_file_path")
-    private String gpxFilePath;
 
     @Builder
-    private Route(User user, String title, LineString routeLine, String shareId,
-                  Double totalDistance, Duration totalDuration, Double totalElevationGain, Double averageGradient,
-                  Double minLon, Double minLat, Double maxLon, Double maxLat,
-                  String thumbnailImagePath, String gpxFilePath) {
+    private Route(User user, String title, String description, Double distance, Duration duration, Double elevationGain,
+                  String shareId, String region, String difficulty, String thumbnailImagePath) {
         this.user = user;
         this.title = title;
+        this.description = description;
+        this.distance = distance;
+        this.duration = duration;
+        this.elevationGain = elevationGain;
         this.shareId = shareId;
-        this.routeLine = routeLine;
-        this.totalDistance = totalDistance;
-        this.totalDuration = totalDuration;
-        this.totalElevationGain = totalElevationGain;
-        this.minLon = minLon;
-        this.minLat = minLat;
-        this.maxLon = maxLon;
-        this.maxLat = maxLat;
-        this.averageGradient = averageGradient;
+        this.region = region;
+        this.difficulty = difficulty;
     }
 
     /**
@@ -112,12 +87,16 @@ public class Route extends BaseTimeEntity {
      * @return 거리 (km)
      */
     public double getDistanceInKm() {
-        return new java.math.BigDecimal(this.totalDistance / 1000.0)
+        return new java.math.BigDecimal(this.distance / 1000.0)
                 .setScale(2, java.math.RoundingMode.DOWN)
                 .doubleValue();
     }
 
     public void updateThumbnailImagePath(String thumbnailImagePath) {
         this.thumbnailImagePath = thumbnailImagePath;
+    }
+
+    public void setRouteGeometry(RouteGeometry routeGeometry) {
+        this.routeGeometry = routeGeometry;
     }
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -1,5 +1,7 @@
 package com.ridingmate.api_server.domain.route.entity;
 
+import com.ridingmate.api_server.domain.route.enums.Difficulty;
+import com.ridingmate.api_server.domain.route.enums.Region;
 import com.ridingmate.api_server.domain.user.entity.User;
 import com.ridingmate.api_server.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -53,10 +55,10 @@ public class Route extends BaseTimeEntity {
     private String shareId;
 
     @Column(name = "region")
-    private String region;
+    private Region region;
 
     @Column(name = "difficulty")
-    private String difficulty;
+    private Difficulty difficulty;
 
     @Column(name = "thumbnail_image_path")
     private String thumbnailImagePath;
@@ -70,7 +72,7 @@ public class Route extends BaseTimeEntity {
 
     @Builder
     private Route(User user, String title, String description, Double distance, Duration duration, Double elevationGain,
-                  String shareId, String region, String difficulty, String thumbnailImagePath) {
+                  String shareId) {
         this.user = user;
         this.title = title;
         this.description = description;
@@ -78,8 +80,6 @@ public class Route extends BaseTimeEntity {
         this.duration = duration;
         this.elevationGain = elevationGain;
         this.shareId = shareId;
-        this.region = region;
-        this.difficulty = difficulty;
     }
 
     /**

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -9,7 +9,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.locationtech.jts.geom.LineString;
 
 import java.time.Duration;
 
@@ -54,9 +53,11 @@ public class Route extends BaseTimeEntity {
     @Column(name = "share_id", nullable = false)
     private String shareId;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "region")
     private Region region;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "difficulty")
     private Difficulty difficulty;
 

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGeometry.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGeometry.java
@@ -10,7 +10,7 @@ import org.locationtech.jts.geom.LineString;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "route_geometry")
+@Table(name = "route_geometries")
 public class RouteGeometry {
 
     @Id
@@ -39,7 +39,7 @@ public class RouteGeometry {
     @Column(name = "average_gradient", nullable = false)
     private double averageGradient;
 
-    @Column(name = "route_line", nullable = false, columnDefinition = "LineString")
+    @Column(name = "route_line", nullable = false, columnDefinition = "geometry(LineString, 4326)")
     private LineString routeLine;
 
     @Builder

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGeometry.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/RouteGeometry.java
@@ -1,0 +1,57 @@
+package com.ridingmate.api_server.domain.route.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.LineString;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "route_geometry")
+public class RouteGeometry {
+
+    @Id
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "route_id")
+    private Route route;
+
+    @Column(name = "gpx_file_path")
+    private String gpxFilePath;
+
+    @Column(name = "max_lat", nullable = false)
+    private double maxLat;
+
+    @Column(name = "max_lon", nullable = false)
+    private double maxLon;
+
+    @Column(name = "min_lat", nullable = false)
+    private double minLat;
+
+    @Column(name = "min_lon", nullable = false)
+    private double minLon;
+
+    @Column(name = "average_gradient", nullable = false)
+    private double averageGradient;
+
+    @Column(name = "route_line", nullable = false, columnDefinition = "LineString")
+    private LineString routeLine;
+
+    @Builder
+    public RouteGeometry(Long id, Route route, String gpxFilePath, double maxLat, double maxLon, double minLat, double minLon, double averageGradient, LineString routeLine) {
+        this.id = id;
+        this.route = route;
+        this.gpxFilePath = gpxFilePath;
+        this.maxLat = maxLat;
+        this.maxLon = maxLon;
+        this.minLat = minLat;
+        this.minLon = minLon;
+        this.averageGradient = averageGradient;
+        this.routeLine = routeLine;
+    }
+} 

--- a/src/main/java/com/ridingmate/api_server/domain/route/enums/Difficulty.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/enums/Difficulty.java
@@ -8,5 +8,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Schema(description = "경로 난이도")
 public enum Difficulty {
+    EASY("쉬움"),
+    MEDIUM("보통"),
+    HARD("어려움")
+    ;
 
+    private final String displayName;
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/enums/Difficulty.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/enums/Difficulty.java
@@ -1,0 +1,12 @@
+package com.ridingmate.api_server.domain.route.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "경로 난이도")
+public enum Difficulty {
+
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/enums/RecommendationType.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/enums/RecommendationType.java
@@ -1,0 +1,21 @@
+package com.ridingmate.api_server.domain.route.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "추천 경로 타입")
+public enum RecommendationType {
+    CROSS_COUNTRY("국토 종주", "국토 종주로 선정된 코스"),
+    COMPETITION("대회 코스", "대회에서 주행한 코스"),
+    FAMOUS("유명 코스", "자전거인들 사이에서 유명한 코스")
+    ;
+
+    @Schema(description = "추천 경로 타입 이름")
+    private final String displayName;
+
+    @Schema(description = "추천 경로 타입 설명")
+    private final String description;
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/enums/Region.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/enums/Region.java
@@ -1,0 +1,11 @@
+package com.ridingmate.api_server.domain.route.enums;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Schema(description = "지역")
+public enum Region {
+}

--- a/src/main/java/com/ridingmate/api_server/domain/route/enums/Region.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/enums/Region.java
@@ -4,8 +4,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Schema(description = "지역")
 @Getter
 @RequiredArgsConstructor
-@Schema(description = "지역")
 public enum Region {
+    SEOUL("서울시", "서울 지역"),
+    GANGWON("강원", "강원도"),
+    CHUNGCHEONG("충남", "충청남도"),
+    JEOLLA("전남", "전라남도"),
+    GYEONGSANG("경남", "경상남도"),
+    JEJU("제주", "제주도");
+
+    private final String displayName;
+    private final String description;
 }

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
@@ -48,17 +48,7 @@ public class RouteFacade {
         Route route = routeService.createRoute(request, routeLine);
         s3Manager.uploadByteFiles(route.getThumbnailImagePath(), thumbnailBytes);
 
-        double distanceKm = new BigDecimal(route.getTotalDistance())
-                .setScale(2, RoundingMode.DOWN)
-                .doubleValue();
-
-        return new CreateRouteResponse(
-                route.getId(),
-                route.getTitle(),
-                route.getTotalDuration().toMinutes(),
-                distanceKm,
-                route.getTotalElevationGain()
-                );
+        return CreateRouteResponse.from(route);
     }
 
     public ShareRouteResponse shareRoute(Long routeId) {

--- a/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/facade/RouteFacade.java
@@ -66,11 +66,12 @@ public class RouteFacade {
         // Service에서 경로 목록 조회
         Page<Route> routePage = routeService.getRoutesByUser(userId, request);
 
-        // DTO 생성 시 썸네일 URL 추가
+        // DTO 생성 시 썸네일 URL과 프로필 이미지 URL 추가
         List<RouteListItemResponse> routeItems = routePage.getContent().stream()
             .map(route -> {
                 String thumbnailUrl = s3Manager.getPresignedUrl(route.getThumbnailImagePath());
-                return RouteListItemResponse.from(route, thumbnailUrl);
+                String profileImageUrl = s3Manager.getPresignedUrl(route.getUser().getProfileImagePath());
+                return RouteListItemResponse.from(route, thumbnailUrl, profileImageUrl);
             })
             .toList();
 

--- a/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/repository/RouteRepository.java
@@ -24,10 +24,10 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         WHERE ur.user = :user
         AND ur.relationType = :relationType
         AND ur.isDelete = false
-        AND (:minDistance IS NULL OR r.totalDistance >= :minDistance)
-        AND (:maxDistance IS NULL OR r.totalDistance <= :maxDistance)
-        AND (:minElevationGain IS NULL OR r.totalElevationGain >= :minElevationGain)
-        AND (:maxElevationGain IS NULL OR r.totalElevationGain <= :maxElevationGain)
+        AND (:minDistance IS NULL OR r.distance >= :minDistance)
+        AND (:maxDistance IS NULL OR r.distance <= :maxDistance)
+        AND (:minElevationGain IS NULL OR r.elevationGain >= :minElevationGain)
+        AND (:maxElevationGain IS NULL OR r.elevationGain <= :maxElevationGain)
         """)
     Page<Route> findByUserAndRelationTypeWithFilters(@Param("user") User user,
                                                      @Param("relationType") RouteRelationType relationType,
@@ -46,10 +46,10 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         WHERE ur.user = :user
         AND ur.relationType IN :relationTypes
         AND ur.isDelete = false
-        AND (:minDistance IS NULL OR r.totalDistance >= :minDistance)
-        AND (:maxDistance IS NULL OR r.totalDistance <= :maxDistance)
-        AND (:minElevationGain IS NULL OR r.totalElevationGain >= :minElevationGain)
-        AND (:maxElevationGain IS NULL OR r.totalElevationGain <= :maxElevationGain)
+        AND (:minDistance IS NULL OR r.distance >= :minDistance)
+        AND (:maxDistance IS NULL OR r.distance <= :maxDistance)
+        AND (:minElevationGain IS NULL OR r.elevationGain >= :minElevationGain)
+        AND (:maxElevationGain IS NULL OR r.elevationGain <= :maxElevationGain)
         """)
     Page<Route> findByUserAndRelationTypesWithFilters(@Param("user") User user,
                                                       @Param("relationTypes") List<RouteRelationType> relationTypes,
@@ -67,10 +67,10 @@ public interface RouteRepository extends JpaRepository<Route, Long> {
         JOIN UserRoute ur ON ur.route = r
         WHERE ur.user = :user
         AND ur.isDelete = false
-        AND (:minDistance IS NULL OR r.totalDistance >= :minDistance)
-        AND (:maxDistance IS NULL OR r.totalDistance <= :maxDistance)
-        AND (:minElevationGain IS NULL OR r.totalElevationGain >= :minElevationGain)
-        AND (:maxElevationGain IS NULL OR r.totalElevationGain <= :maxElevationGain)
+        AND (:minDistance IS NULL OR r.distance >= :minDistance)
+        AND (:maxDistance IS NULL OR r.distance <= :maxDistance)
+        AND (:minElevationGain IS NULL OR r.elevationGain >= :minElevationGain)
+        AND (:maxElevationGain IS NULL OR r.elevationGain <= :maxElevationGain)
         """)
     Page<Route> findByUserWithRelationsAndFilters(@Param("user") User user,
                                                   @Param("minDistance") Double minDistance,

--- a/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/service/RouteService.java
@@ -48,8 +48,6 @@ public class RouteService {
                 .duration(Duration.ofMinutes(request.duration()))
                 .elevationGain(request.elevationGain())
                 .shareId(UUID.randomUUID().toString())
-                .region(request.region())
-                .difficulty(request.difficulty())
                 .build();
 
         // RouteGeometry 엔티티 생성
@@ -138,23 +136,23 @@ public class RouteService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("User not found"));
 
-        Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), request.getSortType().getSort());
+        Pageable pageable = PageRequest.of(request.page(), request.size(), request.sortType().getSort());
 
-        if (request.getRelationTypes() == null || request.getRelationTypes().isEmpty()) {
+        if (request.relationTypes() == null || request.relationTypes().isEmpty()) {
             // 모든 관계 타입 조회
             return routeRepository.findByUserWithRelationsAndFilters(user, 
                     request.getMinDistanceInMeter(), request.getMaxDistanceInMeter(), 
-                    request.getMinElevationGain(), request.getMaxElevationGain(), pageable);
-        } else if (request.getRelationTypes().size() == 1) {
+                    request.minElevationGain(), request.maxElevationGain(), pageable);
+        } else if (request.relationTypes().size() == 1) {
             // 단일 관계 타입 조회
-            return routeRepository.findByUserAndRelationTypeWithFilters(user, request.getRelationTypes().get(0), 
+            return routeRepository.findByUserAndRelationTypeWithFilters(user, request.relationTypes().get(0),
                     request.getMinDistanceInMeter(), request.getMaxDistanceInMeter(), 
-                    request.getMinElevationGain(), request.getMaxElevationGain(), pageable);
+                    request.minElevationGain(), request.maxElevationGain(), pageable);
         } else {
             // 여러 관계 타입 조회
-            return routeRepository.findByUserAndRelationTypesWithFilters(user, request.getRelationTypes(), 
+            return routeRepository.findByUserAndRelationTypesWithFilters(user, request.relationTypes(),
                     request.getMinDistanceInMeter(), request.getMaxDistanceInMeter(), 
-                    request.getMinElevationGain(), request.getMaxElevationGain(), pageable);
+                    request.minElevationGain(), request.maxElevationGain(), pageable);
         }
     }
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
1. 추가로 생성된 기획에 맞추어 활동 기록 관련한 엔티티를 생성하였습니다
- Activity: 주행 기록 메인 데이터
- ActivityImage: 주행 기록에 업로드한 사진 관련 데이터
- ActivityPerformance: 주행 기록 관련하여 세부적인 데이터
- ActivityGpsLog: 세부적인 위치별 데이터로 주로 시계열 데이터로 작성됩니다. 현재는 Postgres에 같이 구성하였으나 추후에 테스트를 통해 MongoDB로 분리 가능합니다.

2. 엔티티 변경에 따른 기존 API 로직 수정

3. Route 목록을 불러오는 API에서 경로를 생성한 사용자 관련한 정보가 필요하여 추가하였습니다.
현재 userId, nickname, profileImage를 보내주고 있습니다. 필요한 정보가 추가적으로 있으시면 말씀해주시면 감사하겠습니다. @Ag-crane 

## PR 포인트

## 고민과 학습내용

## 스크린샷
