### PR TITLE
[Fix] 경로 목록에서 상승 고도를 미터 단위 소수 첫번째 자리까지만 보여주도록 수정

### DIFF
--- a/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteListItemResponse.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/dto/response/RouteListItemResponse.java
@@ -50,7 +50,7 @@ public record RouteListItemResponse(
                 thumbnailUrl,
                 route.getCreatedAt(),
                 route.getDistanceInKm(),
-                route.getElevationGain(),
+                route.getRoundedElevationGain(),
                 route.getUser().getId(),
                 route.getUser().getNickname(),
                 profileImageUrl

--- a/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
+++ b/src/main/java/com/ridingmate/api_server/domain/route/entity/Route.java
@@ -93,6 +93,14 @@ public class Route extends BaseTimeEntity {
                 .doubleValue();
     }
 
+    /**
+     * 총 상승 고도를 소수 둘째자리에서 반올림해서 반환
+     * @return 상승 고도 (m)
+     */
+    public double getRoundedElevationGain() {
+        return Math.round(this.elevationGain * 100.0) / 100.0;
+    }
+
     public void updateThumbnailImagePath(String thumbnailImagePath) {
         this.thumbnailImagePath = thumbnailImagePath;
     }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! [Feat] {제목~~} -->
<!-- Reviewer, Assignees, Label 붙이기 -->

## 작업 내용
기존 경로 목록에서 상승 고도의 소수점이 제한이 없던것을 소수 첫 번째 자리까지만 보여주도록 수정하였습니다.

## PR 포인트

## 고민과 학습내용

## 스크린샷
